### PR TITLE
Added Dockerfile and Docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+MYSQL_ROOT_PASSWORD=root
+MYSQL_DATABASE=usersystem
+MYSQL_USER=root
+MYSQL_PASSWORD=root
+SPRING_DATASOURCE_URL=jdbc:mysql://mysql-cont:3306/usersystem?useSSL=false&serverTimezone=UTC&createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true
+SPRING_DATASOURCE_USERNAME=root
+SPRING_DATASOURCE_PASSWORD=root
+SPRING_JPA_HIBERNATE_DDL_AUTO=update
+SPRING_JPA_SHOW_SQL=true

--- a/Dockerfile.dockerfile
+++ b/Dockerfile.dockerfile
@@ -1,0 +1,37 @@
+#Dockerfile
+
+#Adding required system
+FROM maven:3.8.1-openjdk-17 AS build
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the pom.xml and install dependencies
+COPY pom.xml /app/
+COPY src /app/src
+
+#Run command
+RUN mvn clean package -DskipTests
+
+# contents of the target
+RUN ls -l target/
+
+# Use OpenJDK for running the application
+FROM openjdk:17-jdk-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the built JAR file from the Maven build stage
+COPY --from=build /app/target/rihal-0.0.1-SNAPSHOT.jar rihal-0.0.1-SNAPSHOT.jar
+ENTRYPOINT ["sh", "-c","java", "-jar", "rihal-0.0.1-SNAPSHOT.jar"]
+
+# Expose the application port
+EXPOSE 8080
+
+#ENV
+ENV SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3307/usersystem?useSSL=false&serverTimezone=UTC&createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true
+ENV SPRING_DATASOURCE_USERNAME=root
+ENV SPRING_DATASOURCE_PASSWORD=root
+ENV SPRING_JPA_HIBERNATE_DDL_AUTO=update
+ENV SPRING_JPA_SHOW_SQL=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+
+
+services:
+  mysql:
+    image: mysql
+    container_name: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: usersystem
+      MYSQL_PASSWORD: root
+      MYSQL_TCP_PORT: 3307
+    ports:
+      - "3307:3307"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - demo-network
+
+  userappag:
+    build:
+      context: .
+      dockerfile: Dockerfile.dockerfile
+    container_name: userinfoag
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3307/usersystem?useSSL=false&serverTimezone=UTC&createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: root
+      SPRING_JPA_HIBERNATE_DDL_AUTO: update
+      SPRING_JPA_SHOW_SQL: "true"
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mysql
+    networks:
+      - demo-network
+
+    restart: on-failure
+networks:
+  demo-network:
+
+volumes:
+  mysql_data:


### PR DESCRIPTION
I have containerized a Spring Boot MVC application alongside a MySQL database using Docker and Docker Compose. The Dockerfile is configured to build the Spring Boot application using Maven and OpenJDK 17  which is provided by Docker images, eliminating the need for installation of these tools on the device. The docker-compose.yml file orchestrates the deployment of both the application and the database containers.